### PR TITLE
WIP add variable to indicate whether to create a role or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ resource "aws_iam_role_policy_attachment" "infra_local_policy_attatchment" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| create\_role | Create this IAM role. | bool | `"true"` | no |
 | destination\_account\_ids | The account ids where the target role the call is assuming resides. | list | n/a | yes |
 | destination\_group\_role | The name of the role in the account to be assumed. Again, this should correspond to a group. | string | n/a | yes |
 | iam\_role\_name | The name for the role. Conceptually, this should correspond to a group. | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,7 @@
 # IAM Role
 #
 resource "aws_iam_role" "group" {
+  count              = var.create_role ? 1 : 0
   name               = var.iam_role_name
   description        = "Role for user in the ${var.iam_role_name} group to assume."
   assume_role_policy = data.aws_iam_policy_document.role_assume_role_policy.json

--- a/variables.tf
+++ b/variables.tf
@@ -12,3 +12,9 @@ variable "destination_group_role" {
   description = "The name of the role in the account to be assumed. Again, this should correspond to a group."
   type        = string
 }
+
+variable "create_role" {
+  description = "Create this IAM role."
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This would add a variable (default to true so not a breaking change) that allows users to indicate whether to create a resource in the module or not. That may sound like it makes no sense, but it allows the module to be used in scenarios where you want to create some but not all roles in a module of these modules. Specifically to be used in conjunction currently here: https://github.com/trussworks/legendary-waddle/tree/master/modules/iam-cross-account-access
We're testing whether this is the best way to go about doing this, so do not merge.