### PR TITLE
Add some relevant options. Maintains previous default behavior. 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "role_assume_role_policy" {
 
     # Conditionally require MFA (defaults to true)
     condition {
-      test     = "Bool"
+      test     = var.mfa_condition
       variable = "aws:MultiFactorAuthPresent"
       values   = [tostring(var.require_mfa)]
     }

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,7 @@ resource "aws_iam_role" "group" {
   name               = var.iam_role_name
   description        = "Role for user in the ${var.iam_role_name} group to assume."
   assume_role_policy = data.aws_iam_policy_document.role_assume_role_policy.json
+  max_session_duration = var.role_assumption_max_duration
 }
 
 # Configure a generic policy for assuming roles (conditional MFA)

--- a/variables.tf
+++ b/variables.tf
@@ -20,3 +20,9 @@ variable "require_mfa" {
   type        = bool
   default     = true
 }
+
+variable "mfa_condition" {
+  description = "MFA condition method. Use either Bool or BoolIfExists"
+  type        = string
+  default     = "Bool"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -26,3 +26,9 @@ variable "mfa_condition" {
   type        = string
   default     = "Bool"
 }
+
+variable "role_assumption_max_duration" {
+  description = "Max duration that the assumed role is assumed for Must be between 3600 and 43200 (including)"
+  type        = number
+  default     = 3600
+}


### PR DESCRIPTION
The MFA option should probably be set as default, though I wanted to maintain previous default behavior. 

Timeout option enables keeping sessions open for longer :) 